### PR TITLE
Fix derive macro to take into account reproducability

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -116,7 +116,7 @@ fn generated_values(
             }
         } else {
             quote! {
-                if rand::random() {
+                if rng.gen() {
                     Some(#ts_value)
                 } else {
                     None

--- a/src/gen_enum.rs
+++ b/src/gen_enum.rs
@@ -53,7 +53,7 @@ pub fn generate(name: &Ident, trait_methods: &mut TraitMethods, de: DataEnum) ->
         })
         .collect::<Vec<_>>();
     quote! {
-        let random_val = rand::thread_rng().gen_range(0..#variants_len);
+        let random_val = rng.gen_range(0..#variants_len);
 
         match random_val {
             #(#range => #ts,)*


### PR DESCRIPTION
My use case is a bullshit generator that uses seeded generation as a saving mechanism. Clearly using `rand::thread_rng()` to generate a random range rather than the rng provided to you was a mistake (right?)