### PR TITLE
Add docs

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,121 +1,135 @@
+#![warn(missing_docs)]
+#![allow(dead_code)]
+//! Example for using the `rand_derive2` crate.
+
+use rand_derive2::RandGen;
+
+#[derive(RandGen)]
+struct SomeFields {
+    age: i32,
+    byte: u8,
+}
+
+/// Documented
+#[derive(RandGen)]
+pub struct UnitStruct;
+
+/// Documented
+#[derive(RandGen)]
+pub struct Recursive {
+    field0: SomeFields,
+    field1: std::string::String,
+    field2: uuid::Uuid,
+    field3: UnitStruct,
+    field4: Vec<u8>,
+    field5: std::vec::Vec<u8>,
+    #[rand_derive(default)]
+    field6: std::string::String,
+}
+
+/// Documented
+#[derive(RandGen)]
+pub struct CustomRand {
+    #[rand_derive(custom)]
+    field0: &'static str,
+    #[rand_derive(custom)]
+    field1: Vec<i32>,
+    #[rand_derive(custom)]
+    field2: UnitStruct,
+}
+
+impl CustomRand {
+    const STRING: &'static str = "string";
+
+    fn vec() -> Vec<i32> {
+        vec![1, 2]
+    }
+}
+
+impl TestDataProviderForCustomRand for CustomRand {
+    fn generate_field0<R: rand::Rng + ?Sized>(_: &mut R) -> &'static str {
+        CustomRand::STRING
+    }
+
+    fn generate_field1<R: rand::Rng + ?Sized>(_: &mut R) -> Vec<i32> {
+        CustomRand::vec()
+    }
+
+    fn generate_field2<R: rand::Rng + ?Sized>(_: &mut R) -> UnitStruct {
+        UnitStruct
+    }
+}
+
+/// Documented
+#[derive(RandGen)]
+struct DefaultVecIsEmptyVec {
+    #[rand_derive(empty)]
+    empty_vec: Vec<i32>,
+}
+
+#[derive(RandGen)]
+struct UnnamedBoi(SomeFields, String, i32);
+
+/// Documented
+#[derive(RandGen)]
+#[allow(missing_docs)]
+pub enum SomeEnum {
+    Empty,
+    Named { some_field: i32, another_field: i32 },
+    Unnamed(i32, i32),
+}
+
+/// Docuemnted
+#[derive(RandGen, PartialEq, Debug)]
+#[allow(missing_docs)]
+pub enum SomeEnumSkipVariants {
+    #[rand_derive(skip)]
+    SkipMe,
+    DontSkipMe,
+    DontSkipMeAlso,
+}
+
+/// Documented
+#[derive(RandGen)]
+#[allow(dead_code)]
+pub struct Options {
+    #[rand_derive(some)]
+    field0: Option<i32>,
+    field1: Option<i32>,
+}
+
+/// Documented
+#[derive(RandGen)]
+#[allow(dead_code)]
+pub struct PleasePanic {
+    #[rand_derive(panic)]
+    some_property: i32,
+}
+
+/// Documented
+#[derive(RandGen)]
+#[allow(dead_code)]
+pub struct NoneOption {
+    #[rand_derive(none)]
+    some_property: Option<i32>,
+}
+#[derive(RandGen)]
+struct Fixed {
+    #[rand_derive(fixed = "static")]
+    str: &'static str,
+    #[rand_derive(fixed = "Some String")]
+    string: String,
+    #[rand_derive(fixed = "1")]
+    i32: i32,
+    #[rand_derive(fixed = "false")]
+    bool_false: bool,
+    #[rand_derive(fixed = "true")]
+    bool_true: bool,
+}
+
 #[cfg(test)]
 mod test {
-    use rand_derive2::RandGen;
-
-    #[derive(RandGen)]
-    #[allow(dead_code)]
-    struct SomeFields {
-        age: i32,
-        byte: u8
-    }
-
-    #[derive(RandGen)]
-    pub struct UnitStruct;
-
-    #[derive(RandGen)]
-    #[allow(dead_code)]
-    struct Recursive {
-        field0: SomeFields,
-        field1: std::string::String,
-        field2: uuid::Uuid,
-        field3: UnitStruct,
-        field4: Vec<u8>,
-        field5: std::vec::Vec<u8>,
-        #[rand_derive(default)]
-        field6: std::string::String,
-    }
-
-    #[derive(RandGen)]
-    #[allow(dead_code)]
-    struct CustomRand {
-        #[rand_derive(custom)]
-        field0: &'static str,
-        #[rand_derive(custom)]
-        field1: Vec<i32>,
-        #[rand_derive(custom)]
-        field2: UnitStruct
-    }
-
-    impl CustomRand {
-        const STRING: &'static str = "string";
-
-        fn vec() -> Vec<i32> {
-            vec![1, 2]
-        }
-    }
-
-    impl TestDataProviderForCustomRand for CustomRand {
-        fn generate_field0<R: rand::Rng + ?Sized>(_: &mut R) -> &'static str {
-            CustomRand::STRING
-        }
-
-        fn generate_field1<R: rand::Rng + ?Sized>(_: &mut R) -> Vec<i32> {
-            CustomRand::vec()
-        }
-
-        fn generate_field2<R: rand::Rng + ?Sized>(_: &mut R) -> UnitStruct {
-            UnitStruct
-        }
-    }
-
-    #[derive(RandGen)]
-    struct DefaultVecIsEmptyVec {
-        #[rand_derive(empty)]
-        empty_vec: Vec<i32>
-    }
-
-    #[derive(RandGen)]
-    struct UnnamedBoi(SomeFields, String, i32);
-
-    #[derive(RandGen)]
-    pub enum SomeEnum {
-        Empty,
-        Named { some_field: i32, another_field: i32 },
-        Unnamed(i32, i32)
-    }
-
-    #[derive(RandGen, PartialEq, Debug)]
-    pub enum SomeEnumSkipVariants {
-        #[rand_derive(skip)]
-        SkipMe,
-        DontSkipMe,
-        DontSkipMeAlso
-    }
-
-    #[derive(RandGen)]
-    #[allow(dead_code)]
-    struct Options {
-        #[rand_derive(some)]
-        field0: Option<i32>,
-        field1: Option<i32>
-    }
-
-    #[derive(RandGen)]
-    #[allow(dead_code)]
-    struct PleasePanic {
-        #[rand_derive(panic)]
-        some_property: i32
-    }
-
-    #[derive(RandGen)]
-    #[allow(dead_code)]
-    struct NoneOption {
-        #[rand_derive(none)]
-        some_property: Option<i32>
-    }
-    #[derive(RandGen)]
-    struct Fixed {
-        #[rand_derive(fixed = "static")]
-        str: &'static str,
-        #[rand_derive(fixed = "Some String")]
-        string: String,
-        #[rand_derive(fixed = "1")]
-        i32: i32,
-        #[rand_derive(fixed = "false")]
-        bool_false: bool,
-        #[rand_derive(fixed = "true")]
-        bool_true: bool
-    }
+    use super::*;
 
     #[test]
     fn test_customize() {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -165,18 +165,16 @@ fn add_to_trait_methods(
     trait_methods: &mut TraitMethods,
 ) -> TokenStream {
     let trait_name = trait_name(type_ident);
-    let generate_ty_name = match field_ident {
-        None => format_ident!("generate_random_{}", ty_str.to_lowercase()),
-        Some(f) => format_ident!("generate_{}", f),
+    let (generation_prefix, field_name) = match field_ident {
+        None => ("generate_random_", ty_str.to_lowercase()),
+        Some(f) => ("generate_", f.to_string()),
     };
 
-    let doc_msg = format!(
-        "Generates a custom random instance of `{}`", 
-        field_ident.as_ref().map(|x| x.to_string()).unwrap_or(ty_str.to_string())
-    );
+    let generate_ty_name = format!("{generation_prefix}{field_name}");
+    let doc_msg = format!("Generates a custom random instance of `{}`", field_name);
 
     trait_methods.insert(
-        generate_ty_name.to_string(),
+        generate_ty_name.clone(),
         quote! {
             #[doc = #doc_msg]
             fn #generate_ty_name<R: rand::Rng + ?Sized>(rng: &mut R) -> #ty;

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -25,7 +25,10 @@ pub(crate) fn transform(input: DeriveInput) -> TokenStream {
         let trait_methods = trait_methods.values().cloned().collect::<Vec<_>>();
         let trait_name = trait_name(name);
 
+        let doc_msg = format!("Derived trait used to customize the generation of the type `{}`", name);
+
         tokens.extend(quote! {
+            #[doc = #doc_msg]
             pub trait #trait_name {
                 #(#trait_methods)*
             }
@@ -45,10 +48,12 @@ pub(crate) fn transform(input: DeriveInput) -> TokenStream {
         }
 
         impl #name {
+            #[doc = "Generates a random instance of this type"]
             pub fn generate_random() -> Self {
                 rand::random()
             }
 
+            #[doc = "Generates a random instance of this type with the possibility to customize it"]
             pub fn generate_random_customize<T: FnOnce(&mut Self)>(customize: T) -> Self {
                 let mut entity = rand::random();
 
@@ -165,10 +170,13 @@ fn add_to_trait_methods(
         Some(f) => format_ident!("generate_{}", f),
     };
 
+    let doc_msg = format!("Generates a custom random instance of the type `{}`", ty_str);
+
     trait_methods.insert(
         generate_ty_name.to_string(),
         quote! {
-           fn #generate_ty_name<R: rand::Rng + ?Sized>(rng: &mut R) -> #ty;
+            #[doc = #doc_msg]
+            fn #generate_ty_name<R: rand::Rng + ?Sized>(rng: &mut R) -> #ty;
         },
     );
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -25,7 +25,7 @@ pub(crate) fn transform(input: DeriveInput) -> TokenStream {
         let trait_methods = trait_methods.values().cloned().collect::<Vec<_>>();
         let trait_name = trait_name(name);
 
-        let doc_msg = format!("Derived trait used to customize the generation of the type `{}`", name);
+        let doc_msg = format!("Derived trait used to customize the generation of type `{}`", name);
 
         tokens.extend(quote! {
             #[doc = #doc_msg]
@@ -170,7 +170,10 @@ fn add_to_trait_methods(
         Some(f) => format_ident!("generate_{}", f),
     };
 
-    let doc_msg = format!("Generates a custom random instance of the type `{}`", ty_str);
+    let doc_msg = format!(
+        "Generates a custom random instance of `{}`", 
+        field_ident.as_ref().map(|x| x.to_string()).unwrap_or(ty_str.to_string())
+    );
 
     trait_methods.insert(
         generate_ty_name.to_string(),


### PR DESCRIPTION
I'm currently using `rand_derive2` on a project with the lint `#![warn(missing_docs)]`. However, the implementation of derive macro for `RandGen` doesn't have docs and I get a warning for every use of `#[derive(RandGen)]`.

So, this pull requests adds docs. I added them in 4 places, which seem to be all there is. Feel free to change any of the messages or make them `#[doc(hidden)]`. I don't mind the actual documentation, I just want the errors to go away 😊

Also, I changed the example to show that you can enable this lint without warnings. It's not super pretty so, again, feel free to add it as a separate example or to remove it entirely. 