### PR TITLE
Update to rand 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_derive2"
-version = "0.1.21"
+version = "0.2.0"
 authors = ["Jasper Visser <jasperav@hotmail.com>"]
 edition = "2021"
 description = "Generate customizable random types with the rand crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rand_derive2"
 version = "0.2.0"
 authors = ["Jasper Visser <jasperav@hotmail.com>"]
-edition = "2021"
+edition = "2024"
 description = "Generate customizable random types with the rand crate"
 readme = "README.md"
 keywords = ["rand", "random", "generate", "macro", "derive"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://img.shields.io/github/workflow/status/jasperav/rand_derive2/CI/master)](https://github.com/jasperav/rand_derive2/actions)
 
 Derive macro for generating random types with the `rand` crate. 
-It will implement the `rand::distributions::Standard` for a given type.
+It will implement the `rand::distr::StandardUniform` for a given type.
 
 ## Usage
 
@@ -15,7 +15,7 @@ Check out the example crate or follow the instructions below.
 ```toml
 [dependencies]
 rand_derive2 = "0.1"
-rand = "0.8"
+rand = "0.9.1"
 ```
 
 2. Import the macro somewhere in your file where your type is:
@@ -84,7 +84,7 @@ created somewhere, but where? It could be _maybe_ done by leaking the type that 
 - More types from the standard library covered
 - Functions documented
 - Custom trait type/method names
-- Weighted randomization (currently only supports `rand::distributions::Standard`)
+- Weighted randomization (currently only supports `rand::distr::StandardUniform`)
 
 #### License
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Check out the example crate or follow the instructions below.
 
 ```toml
 [dependencies]
-rand_derive2 = "0.1"
-rand = "0.9.1"
+rand_derive2 = "0.2"
+rand = "0.10.0"
 ```
 
 2. Import the macro somewhere in your file where your type is:
@@ -71,7 +71,7 @@ Place `rand_derive(fixed = "MY_VALUE")` above a field to make it generate the fi
 
 ### How it works 
 #### Structs
-It calls `rng.gen()` on all the fields.
+It calls `rng.random()` on all the fields.
 #### Enums 
 It will generate a random variant.
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Jasper Visser <jasperav@hotmail.com>"]
 edition = "2021"
 
 [dependencies]
-rand = "0.8"
+rand = "0.9.1"
 rand_derive2 = { path = "../../rand_derive2" }
 uuid = { version = "1.2", features = ["v4"] }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,9 +2,9 @@
 name = "rand_derive2-example"
 version = "0.1.0"
 authors = ["Jasper Visser <jasperav@hotmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
-rand = "0.9.1"
+rand = "0.10.0"
 rand_derive2 = { path = "../../rand_derive2" }
 uuid = { version = "1.2", features = ["v4"] }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -47,15 +47,15 @@ impl CustomRand {
 }
 
 impl TestDataProviderForCustomRand for CustomRand {
-    fn generate_field0<R: rand::Rng + ?Sized>(_: &mut R) -> &'static str {
+    fn generate_field0<R: rand::RngExt + ?Sized>(_: &mut R) -> &'static str {
         CustomRand::STRING
     }
 
-    fn generate_field1<R: rand::Rng + ?Sized>(_: &mut R) -> Vec<i32> {
+    fn generate_field1<R: rand::RngExt + ?Sized>(_: &mut R) -> Vec<i32> {
         CustomRand::vec()
     }
 
-    fn generate_field2<R: rand::Rng + ?Sized>(_: &mut R) -> UnitStruct {
+    fn generate_field2<R: rand::RngExt + ?Sized>(_: &mut R) -> UnitStruct {
         UnitStruct
     }
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -42,7 +42,7 @@ pub(crate) fn transform(input: DeriveInput) -> TokenStream {
         // Set the attribute unreachable code here, since there is a field attribute 'panic' in which
         // the type can not be generated
         #[allow(unreachable_code)]
-        impl rand::distributions::Distribution<#name> for rand::distributions::Standard {
+        impl rand::distr::Distribution<#name> for rand::distr::StandardUniform {
             fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
                 use rand::Rng;
 
@@ -219,7 +219,7 @@ fn generate_value(ty_str: &str, customizes: &[Customize]) -> TokenStream {
     } else if ty_str == "String" {
         quote! {
             rng
-                .sample_iter(&rand::distributions::Alphanumeric)
+                .sample_iter(&rand::distr::Alphanumeric)
                 .take(10)
                 .map(char::from)
                 .collect()

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -14,8 +14,8 @@ pub(crate) fn transform(input: DeriveInput) -> TokenStream {
     let name = &input.ident;
     let mut trait_methods = TraitMethods::new();
     let ts = match input.data {
-        Data::Struct(ds) => crate::gen_struct::generate(name, &mut trait_methods, ds),
-        Data::Enum(de) => crate::gen_enum::generate(name, &mut trait_methods, de),
+        Data::Struct(ds) => crate::generate_struct::generate(name, &mut trait_methods, ds),
+        Data::Enum(de) => crate::generate_enum::generate(name, &mut trait_methods, de),
         Data::Union(_) => panic!("Unions are currently not supported"),
     };
 
@@ -43,8 +43,8 @@ pub(crate) fn transform(input: DeriveInput) -> TokenStream {
         // the type can not be generated
         #[allow(unreachable_code)]
         impl rand::distr::Distribution<#name> for rand::distr::StandardUniform {
-            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> #name {
-                use rand::Rng;
+            fn sample<R: rand::RngExt + ?Sized>(&self, rng: &mut R) -> #name {
+                use rand::RngExt;
 
                 #ts
             }
@@ -122,7 +122,7 @@ fn generated_values(
             }
         } else {
             quote! {
-                if rng.gen() {
+                if rng.random() {
                     Some(#ts_value)
                 } else {
                     None
@@ -180,7 +180,7 @@ fn add_to_trait_methods(
         generate_ty_name.to_string(),
         quote! {
             #[doc = #doc_msg]
-            fn #generate_ty_name<R: rand::Rng + ?Sized>(rng: &mut R) -> #ty;
+            fn #generate_ty_name<R: rand::RngExt + ?Sized>(rng: &mut R) -> #ty;
         },
     );
 
@@ -230,7 +230,7 @@ fn generate_value(ty_str: &str, customizes: &[Customize]) -> TokenStream {
         }
     } else {
         quote! {
-            rng.gen()
+            rng.random()
         }
     }
 }

--- a/src/generate_enum.rs
+++ b/src/generate_enum.rs
@@ -1,4 +1,4 @@
-use crate::gen::{
+use crate::generate::{
     generated_values_for_named_fields, generated_values_for_unnamed_fields, TraitMethods,
 };
 use crate::parser::{attrs_to_customizes, has_customize, Customize};
@@ -53,7 +53,7 @@ pub fn generate(name: &Ident, trait_methods: &mut TraitMethods, de: DataEnum) ->
         })
         .collect::<Vec<_>>();
     quote! {
-        let random_val = rng.gen_range(0..#variants_len);
+        let random_val = rng.random_range(0..#variants_len);
 
         match random_val {
             #(#range => #ts,)*

--- a/src/generate_struct.rs
+++ b/src/generate_struct.rs
@@ -1,4 +1,4 @@
-use crate::gen::{
+use crate::generate::{
     generated_values_for_named_fields, generated_values_for_unnamed_fields, TraitMethods,
 };
 use proc_macro2::{Ident, TokenStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 use syn::DeriveInput;
 
-mod gen;
-mod gen_enum;
-mod gen_struct;
+mod generate;
+mod generate_enum;
+mod generate_struct;
 pub(crate) mod parser;
 
 #[proc_macro_derive(RandGen, attributes(rand_derive,))]
 pub fn rand_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
 
-    let transform = gen::transform(input);
+    let transform = generate::transform(input);
 
     transform.into()
 }


### PR DESCRIPTION
~~In this PR I renamed the generated symbols according to their new names in rand 0.9+, so the crate works with current versions of rand. I also updated the Readme and examples to use the current version of rand (0.9.1).~~

Since this is a breaking change, I bumped the version number of this crate.
~~I did not bump the edition, since rand 0.9.1 also still uses 2021 edition (although 0.10.0 is supposed to use 2024).~~

Since this PR was created, rand 0.10.0 was released, so I added another commit to update to that version. I also updated the edition of this crate, which required renaming some modules since `gen` is a reserved keyword in the 2024 edition.

Fixes #8 